### PR TITLE
Add comprehensive Javadoc and OpenAPI documentation

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -98,6 +98,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.6.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.f4b6a3</groupId>
             <artifactId>uuid-creator</artifactId>
             <version>6.1.1</version>

--- a/backend/src/main/java/com/historyai/HistoryAiApplication.java
+++ b/backend/src/main/java/com/historyai/HistoryAiApplication.java
@@ -5,6 +5,29 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+/**
+ * Main entry point for the HistoryAI Spring Boot application.
+ *
+ * <p>AI-powered educational platform enabling conversations with historical figures.
+ * The application provides:</p>
+ * <ul>
+ *   <li>RESTful API for character management</li>
+ *   <li>Real-time chat with AI-powered historical personas</li>
+ *   <li>Fact-checking against Wikipedia sources</li>
+ *   <li>Quote enrichment from Wikiquote</li>
+ * </ul>
+ *
+ * <p>Enabled features:</p>
+ * <ul>
+ *   <li>{@link SpringBootApplication} - Spring Boot auto-configuration</li>
+ *   <li>{@link EnableJpaAuditing} - Automatic timestamp management</li>
+ *   <li>{@link EnableCaching} - Response caching for API calls</li>
+ * </ul>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see <a href="https://github.com/Dekrate/history-ai">Project Repository</a>
+ */
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableCaching

--- a/backend/src/main/java/com/historyai/aspect/LoggingAspect.java
+++ b/backend/src/main/java/com/historyai/aspect/LoggingAspect.java
@@ -12,7 +12,22 @@ import org.springframework.stereotype.Component;
 
 /**
  * Aspect for centralized logging across controllers and services.
- * Provides automatic logging of method executions, parameters, and exceptions.
+ *
+ * <p>Provides automatic logging of method executions, parameters, and exceptions
+ * using AOP (Aspect-Oriented Programming). This ensures consistent logging
+ * across the application without duplicating logging code.</p>
+ *
+ * <p>Key features:</p>
+ * <ul>
+ *   <li>Logs entry and exit of controller methods with execution time</li>
+ *   <li>Logs service method execution</li>
+ *   <li>Includes trace ID from MDC for request correlation</li>
+ *   <li>Logs exceptions with full stack traces</li>
+ * </ul>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see org.aspectj.lang.annotation.Aspect
  */
 @Aspect
 @Component

--- a/backend/src/main/java/com/historyai/client/OllamaClient.java
+++ b/backend/src/main/java/com/historyai/client/OllamaClient.java
@@ -24,7 +24,24 @@ import org.springframework.web.client.RestTemplate;
 
 /**
  * Client for interacting with the Ollama API.
- * Provides text generation capabilities using local LLM models.
+ *
+ * <p>Provides text generation capabilities using local LLM models via Ollama.
+ * Supports both synchronous and streaming responses using Server-Sent Events (SSE).</p>
+ *
+ * <p>Key features:</p>
+ * <ul>
+ *   <li>Chat completion with configurable model</li>
+ *   <li>Streaming response support for real-time output</li>
+ *   <li>Timeout configuration</li>
+ *   <li>Connection pooling via RestTemplate</li>
+ * </ul>
+ *
+ * <p>The client connects to a local Ollama instance, which must be running
+ * and accessible at the configured base URL.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see <a href="https://github.com/ollama/ollama">Ollama</a>
  */
 @Component
 public class OllamaClient {

--- a/backend/src/main/java/com/historyai/client/WikidataApiClient.java
+++ b/backend/src/main/java/com/historyai/client/WikidataApiClient.java
@@ -12,7 +12,20 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 /**
- * Client for interacting with Wikidata to validate entity types.
+ * Client for interacting with Wikidata API.
+ *
+ * <p>Provides entity validation and property lookup capabilities:</p>
+ * <ul>
+ *   <li>Validates if a Wikidata entity is a human (Q5)</li>
+ *   <li>Retrieves citizenship/nationality information (P27 property)</li>
+ * </ul>
+ *
+ * <p>Used to ensure Wikipedia articles refer to actual historical persons
+ * and to extract nationality data for character profiles.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see <a href="https://www.wikidata.org/">Wikidata</a>
  */
 @Component
 public class WikidataApiClient {

--- a/backend/src/main/java/com/historyai/client/WikipediaApiClient.java
+++ b/backend/src/main/java/com/historyai/client/WikipediaApiClient.java
@@ -13,7 +13,22 @@ import org.springframework.web.client.RestTemplate;
 
 /**
  * Client for interacting with the Wikipedia REST API.
- * Retrieves summary information about historical characters and topics.
+ *
+ * <p>Retrieves summary information about historical characters and topics
+ * from the Wikipedia REST API. Supports fetching:</p>
+ * <ul>
+ *   <li>Page summaries (title, extract, description)</li>
+ *   <li>Thumbnail images</li>
+ *   <li>Wikidata entity IDs for additional data</li>
+ *   <li>Content URLs for linking to full articles</li>
+ * </ul>
+ *
+ * <p>Uses configurable timeouts and error handling for robust integration.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see WikipediaResponse
+ * @see <a href="https://en.wikipedia.org/api/rest_v1/">Wikipedia REST API</a>
  */
 @Component
 public class WikipediaApiClient {

--- a/backend/src/main/java/com/historyai/client/WikiquoteApiClient.java
+++ b/backend/src/main/java/com/historyai/client/WikiquoteApiClient.java
@@ -13,7 +13,16 @@ import org.springframework.web.client.RestTemplate;
 
 /**
  * Client for interacting with the Wikiquote API.
- * Retrieves page extracts for quotes.
+ *
+ * <p>Fetches famous quotes from Wikiquote to enrich fact-check responses.
+ * Supports both Polish and English Wikiquote sources.</p>
+ *
+ * <p>The client parses the wikitext format returned by the API and extracts
+ * clean quote text for use in the application.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see <a href="https://www.wikiquote.org/">Wikiquote</a>
  */
 @Component
 public class WikiquoteApiClient {

--- a/backend/src/main/java/com/historyai/config/AsyncConfig.java
+++ b/backend/src/main/java/com/historyai/config/AsyncConfig.java
@@ -5,6 +5,19 @@ import java.util.concurrent.Executors;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Configuration for asynchronous task execution.
+ *
+ * <p>Configures thread pools for handling asynchronous operations,
+ * particularly for streaming responses that require long-running tasks.</p>
+ *
+ * <p>Uses Java virtual threads (available in Java 21+) for efficient
+ * handling of concurrent streaming requests.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see java.util.concurrent.Executor
+ */
 @Configuration
 public class AsyncConfig {
 

--- a/backend/src/main/java/com/historyai/config/CorsConfig.java
+++ b/backend/src/main/java/com/historyai/config/CorsConfig.java
@@ -10,6 +10,24 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Configuration for Cross-Origin Resource Sharing (CORS).
+ *
+ * <p>Configures CORS to allow the frontend application to make API requests
+ * to this backend. The allowed origins, methods, and headers are configurable
+ * via application properties.</p>
+ *
+ * <p>Default configuration allows:</p>
+ * <ul>
+ *   <li>Common HTTP methods (GET, POST, PUT, DELETE, OPTIONS)</li>
+ *   <li>Common headers (Authorization, Content-Type, X-Trace-Id)</li>
+ *   <li>Credentials support</li>
+ * </ul>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS">MDN CORS Guide</a>
+ */
 @Configuration
 public class CorsConfig {
 

--- a/backend/src/main/java/com/historyai/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/historyai/config/OpenApiConfig.java
@@ -1,0 +1,37 @@
+package com.historyai.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI historyAiOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("HistoryAI API")
+                        .description("AI-powered educational platform for conversations with historical figures. "
+                                + "Provides character management, real-time chat streaming, and fact-checking capabilities.")
+                        .version("1.0.0")
+                        .contact(new Contact()
+                                .name("HistoryAI Team")
+                                .url("https://github.com/Dekrate/history-ai"))
+                        .license(new License()
+                                .name("MIT")
+                                .url("https://opensource.org/licenses/MIT")))
+                .servers(List.of(
+                        new Server()
+                                .url("http://localhost:8080")
+                                .description("Local development server")))
+                .components(new Components());
+    }
+}

--- a/backend/src/main/java/com/historyai/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/historyai/config/OpenApiConfig.java
@@ -11,6 +11,13 @@ import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
 
+/**
+ * Spring configuration that sets up the OpenAPI/Swagger metadata for the HistoryAI REST API.
+ * <p>
+ * Exposes the generated OpenAPI specification (e.g. at {@code /v3/api-docs}) and the
+ * interactive Swagger UI (commonly available at {@code /swagger-ui/index.html}),
+ * allowing developers to explore and test the API endpoints.
+ */
 @Configuration
 public class OpenApiConfig {
 

--- a/backend/src/main/java/com/historyai/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/historyai/config/OpenApiConfig.java
@@ -5,18 +5,19 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
-import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.List;
-
 /**
  * Spring configuration that sets up the OpenAPI/Swagger metadata for the HistoryAI REST API.
- * <p>
- * Exposes the generated OpenAPI specification (e.g. at {@code /v3/api-docs}) and the
+ *
+ * <p>Exposes the generated OpenAPI specification (e.g. at {@code /v3/api-docs}) and the
  * interactive Swagger UI (commonly available at {@code /swagger-ui/index.html}),
- * allowing developers to explore and test the API endpoints.
+ * allowing developers to explore and test the API endpoints.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see <a href="https://springdoc.org/">springdoc-openapi</a>
  */
 @Configuration
 public class OpenApiConfig {
@@ -35,10 +36,6 @@ public class OpenApiConfig {
                         .license(new License()
                                 .name("MIT")
                                 .url("https://opensource.org/licenses/MIT")))
-                .servers(List.of(
-                        new Server()
-                                .url("http://localhost:8080")
-                                .description("Local development server")))
                 .components(new Components());
     }
 }

--- a/backend/src/main/java/com/historyai/config/TraceIdFilter.java
+++ b/backend/src/main/java/com/historyai/config/TraceIdFilter.java
@@ -17,8 +17,21 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
  * Filter that adds a unique trace ID to each HTTP request for distributed tracing.
- * The trace ID is added to MDC (Mapped Diagnostic Context) for logging correlation
- * and included in response headers for client-side tracking.
+ *
+ * <p>Provides request tracking across the application by:</p>
+ * <ul>
+ *   <li>Generating or extracting a trace ID from the request</li>
+ *   <li>Adding the trace ID to MDC for log correlation</li>
+ *   <li>Including the trace ID in response headers</li>
+ *   <li>Validating incoming trace IDs for security</li>
+ * </ul>
+ *
+ * <p>The trace ID enables correlating logs across different services and
+ * helps with debugging distributed systems.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see org.slf4j.MDC
  */
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)

--- a/backend/src/main/java/com/historyai/controller/CharacterController.java
+++ b/backend/src/main/java/com/historyai/controller/CharacterController.java
@@ -2,6 +2,7 @@ package com.historyai.controller;
 
 import com.historyai.dto.HistoricalCharacterDTO;
 import com.historyai.service.CharacterService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
@@ -19,9 +20,30 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * REST controller for managing historical characters.
+ *
+ * <p>Provides endpoints for:</p>
+ * <ul>
+ *   <li>Listing all characters</li>
+ *   <li>Finding characters by ID, name, era, or nationality</li>
+ *   <li>Searching characters by name</li>
+ *   <li>Creating, updating, and deleting characters</li>
+ *   <li>Importing characters from Wikipedia</li>
+ * </ul>
+ *
+ * <p>All endpoints return appropriate HTTP status codes and follow REST conventions.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see HistoricalCharacterDTO
+ * @see CharacterService
+ * @see io.swagger.v3.oas.annotations.tags.Tag
+ */
 @RestController
 @RequestMapping("/api/characters")
 @Validated
+@Tag(name = "Characters", description = "Historical character management API")
 public class CharacterController {
 
     private final CharacterService characterService;

--- a/backend/src/main/java/com/historyai/controller/FactCheckController.java
+++ b/backend/src/main/java/com/historyai/controller/FactCheckController.java
@@ -31,7 +31,22 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 /**
  * REST controller for fact-checking functionality.
- * Provides endpoints for verifying historical claims using Wikipedia and AI.
+ *
+ * <p>Provides endpoints for verifying historical claims using Wikipedia and AI.
+ * Supports both synchronous fact-checking and streaming responses.</p>
+ *
+ * <p>The controller integrates with:</p>
+ * <ul>
+ *   <li>{@link com.historyai.service.FactCheckService} - Main fact-checking logic</li>
+ *   <li>{@link WikipediaService} - Wikipedia API integration</li>
+ *   <li>{@link WikiquoteService} - Quote retrieval</li>
+ *   <li>{@link OllamaClient} - LLM for verification</li>
+ * </ul>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see FactCheckResult
+ * @see FactCheckRequest
  */
 @RestController
 @RequestMapping("/api/factcheck")

--- a/backend/src/main/java/com/historyai/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/historyai/controller/GlobalExceptionHandler.java
@@ -36,7 +36,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
  * <p>Returns standardized error responses following RFC 7807 Problem Details specification.
  * Includes structured logging and trace ID propagation for debugging.</p>
  *
- * <p>Handles exceptions include:</p>
+ * <p>Handled exceptions include:</p>
  * <ul>
  *   <li>Character not found (404)</li>
  *   <li>Character already exists (409)</li>

--- a/backend/src/main/java/com/historyai/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/historyai/controller/GlobalExceptionHandler.java
@@ -32,8 +32,23 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 
 /**
  * Global exception handler providing centralized error handling across all REST endpoints.
- * Returns standardized error responses following RFC 7807 Problem Details specification.
- * Includes structured logging and trace ID propagation for debugging.
+ *
+ * <p>Returns standardized error responses following RFC 7807 Problem Details specification.
+ * Includes structured logging and trace ID propagation for debugging.</p>
+ *
+ * <p>Handles exceptions include:</p>
+ * <ul>
+ *   <li>Character not found (404)</li>
+ *   <li>Character already exists (409)</li>
+ *   <li>Wikipedia API errors</li>
+ *   <li>Validation errors (400)</li>
+ *   <li>Generic server errors (500)</li>
+ * </ul>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see ErrorResponse
+ * @see <a href="https://tools.ietf.org/html/rfc7807">RFC 7807</a>
  */
 @RestControllerAdvice
 public class GlobalExceptionHandler {

--- a/backend/src/main/java/com/historyai/controller/QuotesController.java
+++ b/backend/src/main/java/com/historyai/controller/QuotesController.java
@@ -14,7 +14,17 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * REST controller for debugging Wikiquote integration.
+ * REST controller for retrieving quotes from Wikiquote.
+ *
+ * <p>Provides a debug endpoint to test Wikiquote integration and retrieve
+ * famous quotes about historical figures.</p>
+ *
+ * <p>Note: This is primarily for debugging and development purposes.
+ * Production use should go through the fact-check endpoint.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see WikiquoteService
  */
 @RestController
 @RequestMapping("/api/quotes")

--- a/backend/src/main/java/com/historyai/controller/WikipediaController.java
+++ b/backend/src/main/java/com/historyai/controller/WikipediaController.java
@@ -15,7 +15,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * REST controller for Wikipedia API integration.
- * Provides endpoints for retrieving historical character information.
+ *
+ * <p>Provides endpoints for retrieving historical character information from Wikipedia.</p>
+ *
+ * <p>Note: Character management should use the main character endpoints.
+ * This controller provides direct Wikipedia lookup for special use cases.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see WikipediaService
+ * @see WikipediaResponse
  */
 @RestController
 @RequestMapping("/api/wikipedia")

--- a/backend/src/main/java/com/historyai/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/historyai/dto/ErrorResponse.java
@@ -7,7 +7,27 @@ import java.util.Map;
 
 /**
  * Standardized error response DTO returned to clients when an error occurs.
- * Follows RFC 7807 Problem Details specification with extensions for better debugging.
+ *
+ * <p>Follows RFC 7807 Problem Details specification with extensions for better debugging.
+ * This DTO provides a consistent error response format across all API endpoints,
+ * making it easier for clients to handle errors programmatically.</p>
+ *
+ * <p>Example error response:</p>
+ * <pre>
+ * {
+ *   "timestamp": "2026-03-11T21:00:00Z",
+ *   "status": 404,
+ *   "error": "Not Found",
+ *   "message": "Character not found: 550e8400-e29b-41d4-a716-446655440000",
+ *   "path": "/api/characters/550e8400-e29b-41d4-a716-446655440000",
+ *   "traceId": "abc123"
+ * }
+ * </pre>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see com.historyai.controller.GlobalExceptionHandler
+ * @see <a href="https://tools.ietf.org/html/rfc7807">RFC 7807 - Problem Details for HTTP APIs</a>
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorResponse {

--- a/backend/src/main/java/com/historyai/dto/FactCheckRequest.java
+++ b/backend/src/main/java/com/historyai/dto/FactCheckRequest.java
@@ -4,18 +4,35 @@ import jakarta.validation.constraints.NotBlank;
 
 /**
  * Request DTO for fact-checking endpoint.
- * Contains the message to be verified and optional character context.
+ *
+ * <p>Contains the message to be verified along with optional historical character context.
+ * The character information is used to fetch relevant Wikipedia data for more accurate
+ * fact-checking against the specific historical figure's biography.</p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * FactCheckRequest request = new FactCheckRequest(
+ *     "Mikołaj Kopernik urodził się w 1473 roku",
+ *     "Mikołaj Kopernik",
+ *     "Polski astronom i matematyk..."
+ * );
+ * </pre>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see FactCheckResult
+ * @see com.historyai.controller.FactCheckController
  */
 public class FactCheckRequest {
 
     /** The message containing claims to be verified */
-    @NotBlank
+    @NotBlank(message = "Message must not be blank")
     private String message;
     
     /** Name of the historical character for Wikipedia lookup */
     private String characterName;
     
-    /** Optional context about the historical character */
+    /** Optional context about the historical character (biography, era, etc.) */
     private String characterContext;
 
     public FactCheckRequest() {

--- a/backend/src/main/java/com/historyai/dto/FactCheckRequest.java
+++ b/backend/src/main/java/com/historyai/dto/FactCheckRequest.java
@@ -26,7 +26,7 @@ import jakarta.validation.constraints.NotBlank;
 public class FactCheckRequest {
 
     /** The message containing claims to be verified */
-    @NotBlank(message = "Message must not be blank")
+    @NotBlank
     private String message;
     
     /** Name of the historical character for Wikipedia lookup */

--- a/backend/src/main/java/com/historyai/dto/FactCheckResult.java
+++ b/backend/src/main/java/com/historyai/dto/FactCheckResult.java
@@ -2,7 +2,27 @@ package com.historyai.dto;
 
 /**
  * Data transfer object representing the result of a fact-check verification.
- * Contains the claim, verification status, source, explanation, and confidence score.
+ *
+ * <p>Contains the original claim, verification status, source information,
+ * human-readable explanation, and confidence score. This DTO is returned by
+ * the fact-checking endpoint to provide users with detailed information
+ * about the accuracy of their statements.</p>
+ *
+ * <p>Example response:</p>
+ * <pre>
+ * {
+ *   "claim": "Mikołaj Kopernik urodził się w 1473 roku",
+ *   "verification": "VERIFIED",
+ *   "source": "Wikipedia: Nicolaus Copernicus",
+ *   "explanation": "According to Wikipedia, Copernicus was born...",
+ *   "confidence": 0.95
+ * }
+ * </pre>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see FactCheckRequest
+ * @see com.historyai.service.FactCheckService
  */
 public class FactCheckResult {
 

--- a/backend/src/main/java/com/historyai/dto/HistoricalCharacterDTO.java
+++ b/backend/src/main/java/com/historyai/dto/HistoricalCharacterDTO.java
@@ -5,6 +5,24 @@ import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Data Transfer Object (DTO) representing a historical character.
+ *
+ * <p>This class is used for transferring character data between layers of the application.
+ * It provides validation support and bidirectional conversion with the {@link HistoricalCharacter} entity.</p>
+ *
+ * <p>Usage:</p>
+ * <ul>
+ *   <li>API requests/responses for character endpoints</li>
+ *   <li>Form submissions for creating/updating characters</li>
+ *   <li>Converting between entity and DTO representations</li>
+ * </ul>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see HistoricalCharacter
+ * @see com.historyai.controller.CharacterController
+ */
 public class HistoricalCharacterDTO {
 
     private UUID id;

--- a/backend/src/main/java/com/historyai/dto/WikipediaResponse.java
+++ b/backend/src/main/java/com/historyai/dto/WikipediaResponse.java
@@ -5,7 +5,25 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Response DTO for Wikipedia REST API.
- * Contains summary information about a Wikipedia article.
+ *
+ * <p>Represents the summary information returned from the Wikipedia REST API
+ * when fetching article content. This DTO is used to parse the JSON response
+ * and extract relevant information about historical figures.</p>
+ *
+ * <p>The response includes:</p>
+ * <ul>
+ *   <li>Title - the article's title</li>
+ *   <li>Extract - a summary/abstract of the article</li>
+ *   <li>Description - brief description from Wikidata</li>
+ *   <li>Wikibase item - Wikidata entity ID for additional data</li>
+ *   <li>Thumbnail - image information (if available)</li>
+ *   <li>Content URLs - links to the full article</li>
+ * </ul>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see com.historyai.client.WikipediaApiClient
+ * @see <a href="https://en.wikipedia.org/api/rest_v1/">Wikipedia REST API</a>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record WikipediaResponse(

--- a/backend/src/main/java/com/historyai/entity/HistoricalCharacter.java
+++ b/backend/src/main/java/com/historyai/entity/HistoricalCharacter.java
@@ -15,46 +15,117 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+/**
+ * JPA entity representing a historical character in the HistoryAI system.
+ *
+ * <p>This entity stores information about historical figures that users can chat with.
+ * Each character has biographical information including name, birth/death years,
+ * nationality, era, and a biography. The entity uses time-ordered UUIDs for
+ * primary key generation and supports automatic auditing of creation/modification timestamps.</p>
+ *
+ * <p>The entity is mapped to the {@code historical_characters} database table
+ * and is managed by JPA repositories in the application.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @since 1.0
+ * @see com.historyai.repository.HistoricalCharacterRepository
+ * @see com.historyai.dto.HistoricalCharacterDTO
+ */
 @Entity
 @Table(name = "historical_characters")
 @EntityListeners(AuditingEntityListener.class)
 public class HistoricalCharacter {
 
+    /**
+     * Unique identifier for the historical character.
+     * Uses time-ordered UUID for better database performance.
+     */
     @Id
     private UUID id;
 
+    /**
+     * Full name of the historical character.
+     * This field is required and cannot be null.
+     */
     @Column(nullable = false)
     private String name;
 
+    /**
+     * Year of birth for the historical character.
+     * Can be null for characters with unknown birth year.
+     */
     @Column(name = "birth_year")
     private Integer birthYear;
 
+    /**
+     * Year of death for the historical character.
+     * Can be null for still-living figures (though unlikely for historical characters)
+     * or for characters with unknown death year.
+     */
     @Column(name = "death_year")
     private Integer deathYear;
 
+    /**
+     * Biographical information about the historical character.
+     * Contains a detailed biography or description of the person's life and achievements.
+     */
     @Column(columnDefinition = "TEXT")
     private String biography;
 
+    /**
+     * URL to an image of the historical character.
+     * Stored as a string up to 512 characters, can be null if no image is available.
+     */
     @Column(name = "image_url", length = 512)
     private String imageUrl;
 
+    /**
+     * Historical era to which this character belongs (e.g., "Renaissance", "XIX wiek").
+     * Helps categorize characters for filtering and display purposes.
+     */
     @Column(length = 100)
     private String era;
 
+    /**
+     * Nationality of the historical character (e.g., "Polska", "Francja").
+     * Used for filtering and display purposes.
+     */
     @Column(length = 100)
     private String nationality;
 
+    /**
+     * Timestamp when this entity was first created.
+     * Automatically managed by Spring Data JPA auditing.
+     */
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    /**
+     * Timestamp when this entity was last modified.
+     * Automatically managed by Spring Data JPA auditing.
+     */
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    /**
+     * Default constructor required by JPA.
+     * Should not be used directly - use the parameterized constructor or
+     * let JPA create instances from the database.
+     */
     public HistoricalCharacter() {
     }
 
+    /**
+     * Constructs a new HistoricalCharacter with the specified basic information.
+     *
+     * @param name        the full name of the historical character (required)
+     * @param biography   the biographical information about the character
+     * @param era         the historical era to which the character belongs
+     * @param nationality the nationality of the character
+     */
     public HistoricalCharacter(String name, String biography, String era, String nationality) {
         this.name = name;
         this.biography = biography;
@@ -66,10 +137,23 @@ public class HistoricalCharacter {
         return id;
     }
 
+    /**
+     * Sets the unique identifier for this historical character.
+     * This method is typically called by JPA when loading from the database.
+     * For new entities, the ID is automatically generated using time-ordered UUID
+     * via the {@link #prePersist()} method.
+     *
+     * @param id the UUID to set as the entity's identifier
+     */
     public void setId(UUID id) {
         this.id = id;
     }
 
+    /**
+     * Generates a time-ordered UUID before persisting the entity
+     * if no ID has been explicitly set.
+     * This ensures consistent ID generation across distributed systems.
+     */
     @PrePersist
     public void prePersist() {
         if (this.id == null) {
@@ -77,74 +161,166 @@ public class HistoricalCharacter {
         }
     }
 
+    /**
+     * Returns the name of the historical character.
+     *
+     * @return the character's full name, or null if not set
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Sets the name of the historical character.
+     *
+     * @param name the full name to set
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Returns the birth year of the historical character.
+     *
+     * @return the birth year, or null if unknown
+     */
     public Integer getBirthYear() {
         return birthYear;
     }
 
+    /**
+     * Sets the birth year of the historical character.
+     *
+     * @param birthYear the year of birth to set
+     */
     public void setBirthYear(Integer birthYear) {
         this.birthYear = birthYear;
     }
 
+    /**
+     * Returns the death year of the historical character.
+     *
+     * @return the death year, or null if unknown or still alive
+     */
     public Integer getDeathYear() {
         return deathYear;
     }
 
+    /**
+     * Sets the death year of the historical character.
+     *
+     * @param deathYear the year of death to set
+     */
     public void setDeathYear(Integer deathYear) {
         this.deathYear = deathYear;
     }
 
+    /**
+     * Returns the biography of the historical character.
+     *
+     * @return the biographical information, or null if not set
+     */
     public String getBiography() {
         return biography;
     }
 
+    /**
+     * Sets the biography of the historical character.
+     *
+     * @param biography the biographical text to set
+     */
     public void setBiography(String biography) {
         this.biography = biography;
     }
 
+    /**
+     * Returns the URL to the character's image.
+     *
+     * @return the image URL, or null if not available
+     */
     public String getImageUrl() {
         return imageUrl;
     }
 
+    /**
+     * Sets the URL to the character's image.
+     *
+     * @param imageUrl the image URL to set (max 512 characters)
+     */
     public void setImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
     }
 
+    /**
+     * Returns the historical era of the character.
+     *
+     * @return the era (e.g., "Renaissance", "XIX wiek"), or null if not set
+     */
     public String getEra() {
         return era;
     }
 
+    /**
+     * Sets the historical era of the character.
+     *
+     * @param era the era to set
+     */
     public void setEra(String era) {
         this.era = era;
     }
 
+    /**
+     * Returns the nationality of the historical character.
+     *
+     * @return the nationality (e.g., "Polska", "Francja"), or null if not set
+     */
     public String getNationality() {
         return nationality;
     }
 
+    /**
+     * Sets the nationality of the historical character.
+     *
+     * @param nationality the nationality to set
+     */
     public void setNationality(String nationality) {
         this.nationality = nationality;
     }
 
+    /**
+     * Returns the timestamp when this entity was created.
+     *
+     * @return the creation timestamp, or null if not yet persisted
+     */
     public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
+    /**
+     * Sets the creation timestamp.
+     * Typically managed automatically by Spring Data JPA auditing.
+     *
+     * @param createdAt the timestamp to set
+     */
     public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
     }
 
+    /**
+     * Returns the timestamp when this entity was last modified.
+     *
+     * @return the last modification timestamp, or null if not yet persisted
+     */
     public LocalDateTime getUpdatedAt() {
         return updatedAt;
     }
 
+    /**
+     * Sets the last modification timestamp.
+     * Typically managed automatically by Spring Data JPA auditing.
+     *
+     * @param updatedAt the timestamp to set
+     */
     public void setUpdatedAt(LocalDateTime updatedAt) {
         this.updatedAt = updatedAt;
     }

--- a/backend/src/main/java/com/historyai/exception/CharacterNotFoundInWikipediaException.java
+++ b/backend/src/main/java/com/historyai/exception/CharacterNotFoundInWikipediaException.java
@@ -2,6 +2,13 @@ package com.historyai.exception;
 
 /**
  * Exception thrown when a character is not found in Wikipedia.
+ *
+ * <p>This exception indicates that a search for a historical character
+ * in the Wikipedia API did not return any results. It typically results
+ * in a 404 NOT_FOUND HTTP response when importing characters from Wikipedia.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
  */
 public class CharacterNotFoundInWikipediaException extends RuntimeException {
 

--- a/backend/src/main/java/com/historyai/exception/WikipediaApiException.java
+++ b/backend/src/main/java/com/historyai/exception/WikipediaApiException.java
@@ -2,6 +2,14 @@ package com.historyai.exception;
 
 /**
  * Exception thrown when Wikipedia API call fails.
+ *
+ * <p>Represents a general failure when communicating with the Wikipedia API,
+ * such as network errors, timeouts, or unexpected response formats.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see CharacterNotFoundInWikipediaException
+ * @see WikipediaRateLimitException
  */
 public class WikipediaApiException extends RuntimeException {
 

--- a/backend/src/main/java/com/historyai/exception/WikipediaRateLimitException.java
+++ b/backend/src/main/java/com/historyai/exception/WikipediaRateLimitException.java
@@ -2,6 +2,17 @@ package com.historyai.exception;
 
 /**
  * Exception thrown when Wikipedia API rate limit is exceeded.
+ *
+ * <p>Indicates that the application has made too many requests to the Wikipedia API
+ * and has been temporarily blocked. The application implements rate limiting
+ * to respect Wikipedia's usage policies.</p>
+ *
+ * <p>When this exception occurs, the application should wait before making
+ * additional requests to the Wikipedia API.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see WikipediaApiException
  */
 public class WikipediaRateLimitException extends RuntimeException {
 

--- a/backend/src/main/java/com/historyai/repository/HistoricalCharacterRepository.java
+++ b/backend/src/main/java/com/historyai/repository/HistoricalCharacterRepository.java
@@ -36,7 +36,7 @@ public interface HistoricalCharacterRepository extends JpaRepository<HistoricalC
     /**
      * Finds a historical character by exact name match.
      *
-     * @param name the name to search for (case-insensitive via repository implementation)
+     * @param name the name to search for (exact, case-sensitive match as defined by the database collation)
      * @return an {@link Optional} containing the character if found, or empty if not found
      */
     Optional<HistoricalCharacter> findByName(String name);

--- a/backend/src/main/java/com/historyai/repository/HistoricalCharacterRepository.java
+++ b/backend/src/main/java/com/historyai/repository/HistoricalCharacterRepository.java
@@ -9,17 +9,71 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+/**
+ * JPA Repository interface for {@link HistoricalCharacter} entities.
+ *
+ * <p>Provides database access methods for historical character data.
+ * Extends {@link JpaRepository} to inherit standard CRUD operations
+ * and pagination support.</p>
+ *
+ * <p>Custom query methods include:</p>
+ * <ul>
+ *   <li>Find by exact name match</li>
+ *   <li>Find by era</li>
+ *   <li>Find by nationality</li>
+ *   <li>Search by name (case-insensitive partial match)</li>
+ *   <li>Check if character exists by name</li>
+ * </ul>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see HistoricalCharacter
+ * @see JpaRepository
+ */
 @Repository
 public interface HistoricalCharacterRepository extends JpaRepository<HistoricalCharacter, UUID> {
 
+    /**
+     * Finds a historical character by exact name match.
+     *
+     * @param name the name to search for (case-insensitive via repository implementation)
+     * @return an {@link Optional} containing the character if found, or empty if not found
+     */
     Optional<HistoricalCharacter> findByName(String name);
 
+    /**
+     * Finds all historical characters belonging to a specific era.
+     *
+     * @param era the era to filter by (e.g., "Renaissance", "XIX wiek")
+     * @return a list of characters belonging to the specified era, or empty list if none found
+     */
     List<HistoricalCharacter> findByEra(String era);
 
+    /**
+     * Finds all historical characters with a specific nationality.
+     *
+     * @param nationality the nationality to filter by (e.g., "Polska", "Francja")
+     * @return a list of characters with the specified nationality, or empty list if none found
+     */
     List<HistoricalCharacter> findByNationality(String nationality);
 
+    /**
+     * Searches for characters by name using case-insensitive partial matching.
+     *
+     * <p>The search wraps the query in wildcards to match names containing
+     * the search term anywhere in the name.</p>
+     *
+     * @param query the search term to match against character names
+     * @return a list of characters whose names contain the query (case-insensitive)
+     */
     @Query("SELECT c FROM HistoricalCharacter c WHERE LOWER(c.name) LIKE LOWER(CONCAT('%', :query, '%'))")
     List<HistoricalCharacter> searchByName(@Param("query") String query);
 
+    /**
+     * Checks if a character with the given name already exists.
+     *
+     * @param name the name to check for existence
+     * @return true if a character with the given name exists, false otherwise
+     */
     boolean existsByName(String name);
 }

--- a/backend/src/main/java/com/historyai/service/CharacterService.java
+++ b/backend/src/main/java/com/historyai/service/CharacterService.java
@@ -16,6 +16,29 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Service layer for managing historical characters.
+ *
+ * <p>Provides business logic for CRUD operations on historical characters,
+ * including search, filtering, and importing characters from Wikipedia.
+ * All read operations are transactional, while write operations use
+ * explicit transaction boundaries.</p>
+ *
+ * <p>Key responsibilities:</p>
+ * <ul>
+ *   <li>Retrieve characters by various criteria (ID, name, era, nationality)</li>
+ *   <li>Search characters by name</li>
+ *   <li>Create, update, and delete characters</li>
+ *   <li>Import characters from Wikipedia</li>
+ *   <li>Validate business rules (birth/death years, unique names)</li>
+ * </ul>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see HistoricalCharacter
+ * @see HistoricalCharacterDTO
+ * @see com.historyai.controller.CharacterController
+ */
 @Service
 @Transactional(readOnly = true)
 public class CharacterService {
@@ -25,11 +48,22 @@ public class CharacterService {
     private final HistoricalCharacterRepository repository;
     private final WikipediaService wikipediaService;
 
+    /**
+     * Constructs a new CharacterService with the required dependencies.
+     *
+     * @param repository       the character repository for database operations
+     * @param wikipediaService the Wikipedia service for importing characters
+     */
     public CharacterService(final HistoricalCharacterRepository repository, WikipediaService wikipediaService) {
         this.repository = repository;
         this.wikipediaService = wikipediaService;
     }
 
+    /**
+     * Retrieves all historical characters from the database.
+     *
+     * @return a list of all characters as DTOs, or an empty list if none exist
+     */
     public List<HistoricalCharacterDTO> findAll() {
         return repository.findAll()
                 .stream()
@@ -37,16 +71,34 @@ public class CharacterService {
                 .toList();
     }
 
+    /**
+     * Finds a character by its unique identifier.
+     *
+     * @param id the UUID of the character to find
+     * @return an Optional containing the character DTO if found, or empty if not found
+     */
     public Optional<HistoricalCharacterDTO> findById(UUID id) {
         return repository.findById(id)
                 .map(HistoricalCharacterDTO::fromEntity);
     }
 
+    /**
+     * Finds a character by exact name match.
+     *
+     * @param name the name to search for
+     * @return an Optional containing the character DTO if found, or empty if not found
+     */
     public Optional<HistoricalCharacterDTO> findByName(String name) {
         return repository.findByName(name)
                 .map(HistoricalCharacterDTO::fromEntity);
     }
 
+    /**
+     * Finds all characters belonging to a specific historical era.
+     *
+     * @param era the era to filter by (e.g., "Renaissance", "XIX wiek")
+     * @return a list of matching character DTOs, or an empty list if none match
+     */
     public List<HistoricalCharacterDTO> findByEra(String era) {
         return repository.findByEra(era)
                 .stream()
@@ -54,6 +106,12 @@ public class CharacterService {
                 .toList();
     }
 
+    /**
+     * Finds all characters with a specific nationality.
+     *
+     * @param nationality the nationality to filter by (e.g., "Polska", "Francja")
+     * @return a list of matching character DTOs, or an empty list if none match
+     */
     public List<HistoricalCharacterDTO> findByNationality(String nationality) {
         return repository.findByNationality(nationality)
                 .stream()
@@ -61,6 +119,12 @@ public class CharacterService {
                 .toList();
     }
 
+    /**
+     * Searches for characters by name using case-insensitive partial matching.
+     *
+     * @param query the search term to match against character names
+     * @return a list of matching character DTOs, or an empty list if none match
+     */
     public List<HistoricalCharacterDTO> search(String query) {
         return repository.searchByName(query)
                 .stream()
@@ -68,6 +132,17 @@ public class CharacterService {
                 .toList();
     }
 
+    /**
+     * Saves a new historical character to the database.
+     *
+     * <p>Validates that birth year is before death year (if both provided)
+     * and that no character with the same name already exists.</p>
+     *
+     * @param dto the character DTO containing the data to save
+     * @return the saved character DTO with generated ID and timestamps
+     * @throws IllegalArgumentException if birth year is after death year
+     * @throws CharacterAlreadyExistsException if a character with the same name exists
+     */
     @Transactional
     public HistoricalCharacterDTO save(HistoricalCharacterDTO dto) {
         if (dto.getBirthYear() != null && dto.getDeathYear() != null 
@@ -84,6 +159,20 @@ public class CharacterService {
         return HistoricalCharacterDTO.fromEntity(saved);
     }
 
+    /**
+     * Updates an existing historical character.
+     *
+     * <p>Validates that the character exists, birth year is before death year
+     * (if both provided), and that the new name doesn't conflict with another
+     * existing character.</p>
+     *
+     * @param id  the UUID of the character to update
+     * @param dto the character DTO containing the updated data
+     * @return the updated character DTO
+     * @throws CharacterNotFoundException if the character with the given ID doesn't exist
+     * @throws IllegalArgumentException if birth year is after death year
+     * @throws CharacterAlreadyExistsException if another character with the same name exists
+     */
     @Transactional
     public HistoricalCharacterDTO update(UUID id, HistoricalCharacterDTO dto) {
         HistoricalCharacter existing = repository.findById(id)
@@ -112,6 +201,12 @@ public class CharacterService {
         return HistoricalCharacterDTO.fromEntity(updated);
     }
 
+    /**
+     * Deletes a historical character by its unique identifier.
+     *
+     * @param id the UUID of the character to delete
+     * @throws CharacterNotFoundException if the character with the given ID doesn't exist
+     */
     @Transactional
     public void deleteById(UUID id) {
         if (!repository.existsById(id)) {
@@ -120,6 +215,24 @@ public class CharacterService {
         repository.deleteById(id);
     }
 
+    /**
+     * Searches for a character on Wikipedia and imports their information.
+     *
+     * <p>Fetches character information from Wikipedia, extracts relevant data
+     * (name, biography, image, era, nationality), and creates a new character
+     * in the database. If a character with the same name already exists,
+     * returns the existing character instead of creating a duplicate.</p>
+     *
+     * <p>Nationality is determined by:</p>
+     * <ol>
+     *   <li>Querying Wikidata API for citizenship information</li>
+     *   <li>Fallback to extracting nationality from the Wikipedia extract</li>
+     * </ol>
+     *
+     * @param searchQuery the search query to find the character on Wikipedia
+     * @return the imported or existing character as a DTO
+     * @throws CharacterNotFoundInWikipediaException if the character is not found on Wikipedia
+     */
     @Transactional
     public HistoricalCharacterDTO searchAndImportFromWikipedia(String searchQuery) {
         logger.info("Searching and importing character from Wikipedia: {}", searchQuery);
@@ -158,6 +271,15 @@ public class CharacterService {
         return HistoricalCharacterDTO.fromEntity(saved);
     }
 
+    /**
+     * Extracts the historical era from a Wikipedia article extract.
+     *
+     * <p>Analyzes the text for keywords indicating the time period,
+     * including century references and birth year patterns.</p>
+     *
+     * @param extract the Wikipedia article extract text
+     * @return the era string (e.g., "XIX wiek", "Renesans") or "Unknown"
+     */
     private String extractEraFromWiki(String extract) {
         if (extract == null) return "Unknown";
         extract = extract.toLowerCase();
@@ -190,6 +312,15 @@ public class CharacterService {
         return "Unknown";
     }
 
+    /**
+     * Extracts the nationality from a Wikipedia article extract.
+     *
+     * <p>Analyzes the text for keywords indicating the person's nationality
+     * in multiple languages (English, Polish, etc.).</p>
+     *
+     * @param extract the Wikipedia article extract text
+     * @return the nationality string (e.g., "Polska", "Francja") or "Unknown"
+     */
     private String extractNationalityFromWiki(String extract) {
         if (extract == null) return "Unknown";
         extract = extract.toLowerCase();

--- a/backend/src/main/java/com/historyai/service/FactCheckPromptBuilder.java
+++ b/backend/src/main/java/com/historyai/service/FactCheckPromptBuilder.java
@@ -5,7 +5,23 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 /**
- * Builds prompts for fact-checking using shared formatting rules.
+ * Builds prompts for fact-checking using LLM with structured output format.
+ *
+ * <p>Creates optimized prompts for the Ollama LLM to perform fact-checking
+ * on historical claims. The prompt includes:</p>
+ * <ul>
+ *   <li>Character context from the conversation</li>
+ *   <li>Wikipedia reference information</li>
+ *   <li>Relevant quotes from Wikiquote</li>
+ *   <li>Instructions for structured JSON output</li>
+ * </ul>
+ *
+ * <p>The prompt instructs the LLM to respond in the same language as the claim
+ * while keeping the verification keywords in English.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see FactCheckService
  */
 @Component
 public class FactCheckPromptBuilder {

--- a/backend/src/main/java/com/historyai/service/FactCheckService.java
+++ b/backend/src/main/java/com/historyai/service/FactCheckService.java
@@ -12,8 +12,24 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 /**
- * Service for fact-checking historical claims.
- * Uses Wikipedia for context and Ollama (LLM) for verification.
+ * Service for fact-checking historical claims using AI and Wikipedia.
+ *
+ * <p>Provides comprehensive fact-checking capabilities by:</p>
+ * <ul>
+ *   <li>Extracting factual claims from user messages</li>
+ *   <li>Fetching relevant Wikipedia context about the historical figure</li>
+ *   <li>Querying an LLM (via Ollama) to verify claims against Wikipedia context</li>
+ *   <li>Parsing verification results and confidence scores</li>
+ *   <li>Enriching responses with relevant quotes from Wikiquote</li>
+ * </ul>
+ *
+ * <p>The service uses a prompt-based approach where the LLM is instructed to analyze
+ * claims and provide structured verification results.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see FactCheckResult
+ * @see com.historyai.controller.FactCheckController
  */
 @Service
 public class FactCheckService {

--- a/backend/src/main/java/com/historyai/service/WikipediaService.java
+++ b/backend/src/main/java/com/historyai/service/WikipediaService.java
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Service;
  *   <li>Integration with Wikidata for nationality data</li>
  * </ul>
  *
- * <p>The service first tries English Wikipedia, then falls back to Polish Wikipedia
+ * <p>The service first tries Polish Wikipedia, then falls back to English Wikipedia
  * if the character is not found.</p>
  *
  * @author HistoryAI Team

--- a/backend/src/main/java/com/historyai/service/WikipediaService.java
+++ b/backend/src/main/java/com/historyai/service/WikipediaService.java
@@ -15,7 +15,23 @@ import org.springframework.stereotype.Service;
 
 /**
  * Service for retrieving Wikipedia information about historical characters.
- * Provides caching and rate limiting for Wikipedia API calls.
+ *
+ * <p>Provides a unified interface for fetching Wikipedia data with the following features:</p>
+ * <ul>
+ *   <li>Multi-language support (English and Polish Wikipedia)</li>
+ *   <li>Caching of API responses to reduce redundant requests</li>
+ *   <li>Rate limiting to respect Wikipedia's usage policies</li>
+ *   <li>Integration with Wikidata for nationality data</li>
+ * </ul>
+ *
+ * <p>The service first tries English Wikipedia, then falls back to Polish Wikipedia
+ * if the character is not found.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see WikipediaResponse
+ * @see com.historyai.client.WikipediaApiClient
+ * @see <a href="https://en.wikipedia.org/api/rest_v1/">Wikipedia REST API</a>
  */
 @Service
 @CacheConfig(cacheNames = "wikipedia")

--- a/backend/src/main/java/com/historyai/service/WikiquoteService.java
+++ b/backend/src/main/java/com/historyai/service/WikiquoteService.java
@@ -13,7 +13,16 @@ import org.springframework.stereotype.Service;
 
 /**
  * Service for retrieving quotes from Wikiquote.
- * Tries Polish first, then English.
+ *
+ * <p>Fetches famous quotes from Wikiquote to enrich fact-check responses.
+ * Tries Polish Wikiquote first, then falls back to English if no quotes are found.</p>
+ *
+ * <p>Results are cached to minimize API calls and improve response times.</p>
+ *
+ * @author HistoryAI Team
+ * @version 1.0
+ * @see com.historyai.client.WikiquoteApiClient
+ * @see <a href="https://www.wikiquote.org/">Wikiquote</a>
  */
 @Service
 @CacheConfig(cacheNames = "wikiquote")


### PR DESCRIPTION
This PR adds professional Javadoc documentation to all Java classes and integrates OpenAPI/Swagger for API documentation.

## Changes

### OpenAPI/Swagger
- Added springdoc-openapi dependency
- Created OpenApiConfig with application info
- Added @Tag annotations to controllers

### Javadoc Added To
- Entity classes (HistoricalCharacter)
- DTOs (HistoricalCharacterDTO, FactCheckRequest, FactCheckResult, WikipediaResponse, ErrorResponse)
- Repository interfaces (HistoricalCharacterRepository)
- Services (CharacterService, FactCheckService, WikipediaService, WikiquoteService, FactCheckPromptBuilder)
- Clients (OllamaClient, WikipediaApiClient, WikidataApiClient, WikiquoteApiClient)
- Controllers (CharacterController, FactCheckController, QuotesController, WikipediaController, GlobalExceptionHandler)
- Exceptions (all custom exceptions)
- Config (CorsConfig, AsyncConfig, TraceIdFilter, OpenApiConfig)
- Aspect (LoggingAspect)
- Application main class

## Testing
- All tests pass